### PR TITLE
Last chance interception Func and async open rating page

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,8 +40,8 @@ steps:
   displayName: Run Tests
   inputs:
     command: 'test'
-    publishTestResults: true
     projects: '**/tests/RatingGateway.Tests.csproj'
+    arguments: '--collect:"Code Coverage"'
     testRunTitle: 'Shared Layer Tests'
     workingDirectory: '$(System.DefaultWorkingDirectory)'
 

--- a/docs/Griesoft.Xamarin.RatingGateway.xml
+++ b/docs/Griesoft.Xamarin.RatingGateway.xml
@@ -222,7 +222,7 @@
             If you need custom manipulation or reset logic, or if you want to add more complex functionality that the build-in conditions don't provide, 
             you should write a custom condition and inherit from the condition base class <see cref="T:Griesoft.Xamarin.RatingGateway.Conditions.RatingConditionBase`1"/>.
             </remarks>
-            <typeparam name="TConditionType"></typeparam>
+            <typeparam name="TConditionStateType"></typeparam>
         </member>
         <member name="M:Griesoft.Xamarin.RatingGateway.RatingCondition`1.#ctor(`0,System.Func{`0,System.Boolean})">
             <summary>
@@ -243,7 +243,7 @@
             <summary>
             The base class for a condition with an default implementation of the <see cref="T:Griesoft.Xamarin.RatingGateway.Conditions.IRatingCondition"/> interface. Use it to easily create custom conditions.
             </summary>
-            <typeparam name="TConditionType">The type that this condition is dedicated to store, manipulate and evaluate.</typeparam>
+            <typeparam name="TConditionStateType">The type that this condition is dedicated to store, manipulate and evaluate.</typeparam>
             <remarks>
             If you need custom manipulation or reset logic, or if you want to add more complex functionality that the build-in conditions don't provide, 
             you should write a custom condition and inherit from this abstract base class.
@@ -302,7 +302,7 @@
         </member>
         <member name="M:Griesoft.Xamarin.RatingGateway.Conditions.RatingConditionBase`1.ManipulateState(System.Object)">
             <summary>
-            Sets the current state to the specified value if it can be cast to <typeparamref name="TConditionType"/>.
+            Sets the current state to the specified value if it can be cast to <typeparamref name="TConditionStateType"/>.
             </summary>
             <param name="parameter">The value to set as the new current state.</param>
         </member>
@@ -410,8 +410,26 @@
         </member>
         <member name="T:Griesoft.Xamarin.RatingGateway.DefaultRatingView">
             <summary>
-            A default rating view implementation for iOS.
+            A default rating view implementation for .NET Standard.
             </summary>
+            <remarks>
+            If the package is not installed on each platform that it is used on, this will throw a <see cref="T:System.NotImplementedException"/>.
+            </remarks>
+        </member>
+        <member name="M:Griesoft.Xamarin.RatingGateway.DefaultRatingView.#ctor">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="M:Griesoft.Xamarin.RatingGateway.DefaultRatingView.#ctor(System.Func{System.Boolean})">
+            <summary>
+            
+            </summary>
+            <param name="runBeforeOpen">A last chance function that be used to intercept navigating to the review page of your app.</param>
+            <remarks>
+            <paramref name="runBeforeOpen"/> will be only called if the In-App Review process is not available, i.e. just before we would open the Store page of your app.
+            This can be useful to first prompt the user to review your app by opening a pop-up. Not doing so can have a negative impact on user experience.
+            </remarks>
         </member>
         <member name="M:Griesoft.Xamarin.RatingGateway.DefaultRatingView.TryOpenRatingPage">
             <inheritdoc/>

--- a/docs/Griesoft.Xamarin.RatingGateway.xml
+++ b/docs/Griesoft.Xamarin.RatingGateway.xml
@@ -425,13 +425,39 @@
             <summary>
             
             </summary>
-            <param name="runBeforeOpen">A last chance function that be used to intercept navigating to the review page of your app.</param>
+            <param name="runBeforeOpen">A last chance function that can be used to intercept navigating to the review page of your app.</param>
             <remarks>
             <paramref name="runBeforeOpen"/> will be only called if the In-App Review process is not available, i.e. just before we would open the Store page of your app.
             This can be useful to first prompt the user to review your app by opening a pop-up. Not doing so can have a negative impact on user experience.
             </remarks>
         </member>
+        <member name="M:Griesoft.Xamarin.RatingGateway.DefaultRatingView.#ctor(System.Func{System.Threading.Tasks.Task{System.Boolean}})">
+            <summary>
+            
+            </summary>
+            <param name="runBeforeOpenAsync">An <see langword="async"/> last chance function that can be used to intercept navigating to the review page of your app.</param>
+            <remarks>
+            <paramref name="runBeforeOpenAsync"/> will be only called if the In-App Review process is not available, i.e. just before we would open the Store page of your app.
+            This can be useful to first prompt the user to review your app by opening a pop-up. Not doing so can have a negative impact on user experience.
+            </remarks>
+        </member>
+        <member name="M:Griesoft.Xamarin.RatingGateway.DefaultRatingView.#ctor(System.Func{System.Boolean},System.Func{System.Threading.Tasks.Task{System.Boolean}})">
+            <summary>
+            
+            </summary>
+            <param name="runBeforeOpen">A last chance function that can be used to intercept navigating to the review page of your app.</param>
+            <param name="runBeforeOpenAsync">An <see langword="async"/> last chance function that can be used to intercept navigating to the review page of your app.</param>
+            <remarks>
+            <paramref name="runBeforeOpen"/> or <paramref name="runBeforeOpenAsync"/> will be only called if the In-App Review process is not available, i.e. just before we would open the Store page of your app.
+            This can be useful to first prompt the user to review your app by opening a pop-up. Not doing so can have a negative impact on user experience.
+            <para/>
+            Whether the rating view uses the sync or async function depends on which method is called, <see cref="M:Griesoft.Xamarin.RatingGateway.DefaultRatingView.TryOpenRatingPage"/> or <see cref="M:Griesoft.Xamarin.RatingGateway.DefaultRatingView.TryOpenRatingPageAsync"/>.
+            </remarks>
+        </member>
         <member name="M:Griesoft.Xamarin.RatingGateway.DefaultRatingView.TryOpenRatingPage">
+            <inheritdoc/>
+        </member>
+        <member name="M:Griesoft.Xamarin.RatingGateway.DefaultRatingView.TryOpenRatingPageAsync">
             <inheritdoc/>
         </member>
         <member name="T:Griesoft.Xamarin.RatingGateway.ConditionType">
@@ -474,6 +500,11 @@
         <member name="M:Griesoft.Xamarin.RatingGateway.IRatingView.TryOpenRatingPage">
             <summary>
             Try to open the review page for your application.
+            </summary>
+        </member>
+        <member name="M:Griesoft.Xamarin.RatingGateway.IRatingView.TryOpenRatingPageAsync">
+            <summary>
+            Try to open the review page for your application asynchronously.
             </summary>
         </member>
         <member name="T:Griesoft.Xamarin.RatingGateway.RatingGateway">
@@ -604,6 +635,50 @@
             <param name="parameters">A collection of unique condition names and optional parameters for them.</param>
             <param name="manipulateOnly">Set to true if the specified conditions should not be prioritized in the actual evaluation phase and be used for manipulation only. The default is false.</param>
             <remarks>
+            The evaluation process will first manipulate all conditions that allow implicit manipulation by using their parameterless manipulation method.
+            After manipulation, the actual evaluation will happen, and after evaluation has finished all met conditions will be reset which allow automatic reset.
+            <para/>
+            If the specified conditions are not used for manipulation only, they will be prioritized by the evaluator. This means that the prioritized conditions must be
+            met in addition to all prerequisite and required conditions, before evaluating to true.
+            </remarks>
+        </member>
+        <member name="M:Griesoft.Xamarin.RatingGateway.RatingGateway.EvaluateAsync">
+            <summary>
+            Evaluate through all conditions in the collection and if all necessary conditions are met open the rating page asynchronously.
+            </summary>
+            <remarks>
+            Use <see cref="M:Griesoft.Xamarin.RatingGateway.RatingGateway.Evaluate"/> if you are not sure about which one to use.
+            <para/>
+            The evaluation process will first manipulate all conditions that allow implicit manipulation by using their parameterless manipulation method.
+            After manipulation, the actual evaluation will happen, and after evaluation has finished all met conditions will be reset which allow automatic reset.
+            </remarks>
+        </member>
+        <member name="M:Griesoft.Xamarin.RatingGateway.RatingGateway.EvaluateAsync(System.String,System.Object,System.Boolean)">
+            <summary>
+            Evaluate through all conditions in the collection and if all necessary conditions are met open the rating page asynchronously.
+            </summary>
+            <param name="conditionName">The unique name of the condition that should be prioritized.</param>
+            <param name="parameter">An optional parameter that will be passed to the manipulation process for the specified condition.</param>
+            <param name="manipulateOnly">Set to true if the specified condition should not be prioritized in the actual evaluation phase and be used for manipulation only. The default is false.</param>
+            <remarks>
+            Use <see cref="M:Griesoft.Xamarin.RatingGateway.RatingGateway.Evaluate(System.String,System.Object,System.Boolean)"/> if you are not sure about which one to use.
+            <para/>
+            The evaluation process will first manipulate all conditions that allow implicit manipulation by using their parameterless manipulation method.
+            After manipulation, the actual evaluation will happen, and after evaluation has finished all met conditions will be reset which allow automatic reset.
+            <para/>
+            If the specified condition is not used for manipulation only, it will be prioritized by the evaluator. This means that the prioritized condition must be
+            met in addition to all prerequisite and required conditions, before evaluating to true.
+            </remarks>
+        </member>
+        <member name="M:Griesoft.Xamarin.RatingGateway.RatingGateway.EvaluateAsync(System.Collections.Generic.Dictionary{System.String,System.Object},System.Boolean)">
+            <summary>
+            Evaluate through all conditions in the collection and if all necessary conditions are met open the rating page asynchronously.
+            </summary>
+            <param name="parameters">A collection of unique condition names and optional parameters for them.</param>
+            <param name="manipulateOnly">Set to true if the specified conditions should not be prioritized in the actual evaluation phase and be used for manipulation only. The default is false.</param>
+            <remarks>
+            Use <see cref="M:Griesoft.Xamarin.RatingGateway.RatingGateway.Evaluate(System.Collections.Generic.Dictionary{System.String,System.Object},System.Boolean)"/> if you are not sure about which one to use.
+            <para/>
             The evaluation process will first manipulate all conditions that allow implicit manipulation by using their parameterless manipulation method.
             After manipulation, the actual evaluation will happen, and after evaluation has finished all met conditions will be reset which allow automatic reset.
             <para/>

--- a/src/DefaultRatingView.cs
+++ b/src/DefaultRatingView.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Griesoft.Xamarin.RatingGateway
 {
     public sealed partial class DefaultRatingView : IRatingView
     {
         private readonly Func<bool>? _runBeforeOpen;
+        private readonly Func<Task<bool>>? _runBeforeOpenAsync;
 
         /// <summary>
         /// 
@@ -14,7 +16,7 @@ namespace Griesoft.Xamarin.RatingGateway
         /// <summary>
         /// 
         /// </summary>
-        /// <param name="runBeforeOpen">A last chance function that be used to intercept navigating to the review page of your app.</param>
+        /// <param name="runBeforeOpen">A last chance function that can be used to intercept navigating to the review page of your app.</param>
         /// <remarks>
         /// <paramref name="runBeforeOpen"/> will be only called if the In-App Review process is not available, i.e. just before we would open the Store page of your app.
         /// This can be useful to first prompt the user to review your app by opening a pop-up. Not doing so can have a negative impact on user experience.
@@ -24,8 +26,41 @@ namespace Griesoft.Xamarin.RatingGateway
             _runBeforeOpen = runBeforeOpen;
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="runBeforeOpenAsync">An <see langword="async"/> last chance function that can be used to intercept navigating to the review page of your app.</param>
+        /// <remarks>
+        /// <paramref name="runBeforeOpenAsync"/> will be only called if the In-App Review process is not available, i.e. just before we would open the Store page of your app.
+        /// This can be useful to first prompt the user to review your app by opening a pop-up. Not doing so can have a negative impact on user experience.
+        /// </remarks>
+        public DefaultRatingView(Func<Task<bool>>? runBeforeOpenAsync)
+        {
+            _runBeforeOpenAsync = runBeforeOpenAsync;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="runBeforeOpen">A last chance function that can be used to intercept navigating to the review page of your app.</param>
+        /// <param name="runBeforeOpenAsync">An <see langword="async"/> last chance function that can be used to intercept navigating to the review page of your app.</param>
+        /// <remarks>
+        /// <paramref name="runBeforeOpen"/> or <paramref name="runBeforeOpenAsync"/> will be only called if the In-App Review process is not available, i.e. just before we would open the Store page of your app.
+        /// This can be useful to first prompt the user to review your app by opening a pop-up. Not doing so can have a negative impact on user experience.
+        /// <para/>
+        /// Whether the rating view uses the sync or async function depends on which method is called, <see cref="TryOpenRatingPage"/> or <see cref="TryOpenRatingPageAsync"/>.
+        /// </remarks>
+        public DefaultRatingView(Func<bool> runBeforeOpen, Func<Task<bool>>? runBeforeOpenAsync)
+        {
+            _runBeforeOpen = runBeforeOpen;
+            _runBeforeOpenAsync = runBeforeOpenAsync;
+        }
+
         /// <inheritdoc/>
         public void TryOpenRatingPage() => PlatformTryOpenRatingPage(_runBeforeOpen);
+
+        /// <inheritdoc/>
+        public async Task TryOpenRatingPageAsync() => await PlatformTryOpenRatingPageAsync(_runBeforeOpenAsync);
 
         internal static Version ParseVersion(string versionString)
         {

--- a/src/DefaultRatingView.cs
+++ b/src/DefaultRatingView.cs
@@ -4,8 +4,28 @@ namespace Griesoft.Xamarin.RatingGateway
 {
     public sealed partial class DefaultRatingView : IRatingView
     {
+        private readonly Func<bool>? _runBeforeOpen;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public DefaultRatingView() { }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="runBeforeOpen">A last chance function that be used to intercept navigating to the review page of your app.</param>
+        /// <remarks>
+        /// <paramref name="runBeforeOpen"/> will be only called if the In-App Review process is not available, i.e. just before we would open the Store page of your app.
+        /// This can be useful to first prompt the user to review your app by opening a pop-up. Not doing so can have a negative impact on user experience.
+        /// </remarks>
+        public DefaultRatingView(Func<bool> runBeforeOpen)
+        {
+            _runBeforeOpen = runBeforeOpen;
+        }
+
         /// <inheritdoc/>
-        public void TryOpenRatingPage() => PlatformTryOpenRatingPage();
+        public void TryOpenRatingPage() => PlatformTryOpenRatingPage(_runBeforeOpen);
 
         internal static Version ParseVersion(string versionString)
         {

--- a/src/Interface/IRatingView.cs
+++ b/src/Interface/IRatingView.cs
@@ -1,4 +1,6 @@
-﻿namespace Griesoft.Xamarin.RatingGateway
+﻿using System.Threading.Tasks;
+
+namespace Griesoft.Xamarin.RatingGateway
 {
     /// <summary>
     /// The interface for a view which is responsible to prompt the user to review the application.
@@ -13,5 +15,10 @@
         /// Try to open the review page for your application.
         /// </summary>
         void TryOpenRatingPage();
+
+        /// <summary>
+        /// Try to open the review page for your application asynchronously.
+        /// </summary>
+        Task TryOpenRatingPageAsync();
     }
 }

--- a/src/Platforms/Android/DefaultRatingView.cs
+++ b/src/Platforms/Android/DefaultRatingView.cs
@@ -12,8 +12,13 @@ namespace Griesoft.Xamarin.RatingGateway
     {
         private const string MarketUri = "market://details?id=";
 
-        internal static void PlatformTryOpenRatingPage()
+        internal static void PlatformTryOpenRatingPage(System.Func<bool>? runBeforeOpen = default)
         {
+            if (runBeforeOpen != null && !runBeforeOpen())
+            {
+                return;
+            }
+
             if (Application.Context == null)
             {
                 return;

--- a/src/Platforms/Android/DefaultRatingView.cs
+++ b/src/Platforms/Android/DefaultRatingView.cs
@@ -1,4 +1,5 @@
-﻿using Android.App;
+﻿using System.Threading.Tasks;
+using Android.App;
 using Android.Content;
 using Android.Net;
 using Android.OS;
@@ -19,6 +20,21 @@ namespace Griesoft.Xamarin.RatingGateway
                 return;
             }
 
+            NavigateToAppStorePage();
+        }
+
+        internal static async Task PlatformTryOpenRatingPageAsync(System.Func<Task<bool>>? runBeforeOpenAsync = default)
+        {
+            if (runBeforeOpenAsync != null && !await runBeforeOpenAsync())
+            {
+                return;
+            }
+
+            NavigateToAppStorePage();
+        }
+
+        private static void NavigateToAppStorePage()
+        {
             if (Application.Context == null)
             {
                 return;

--- a/src/Platforms/Ios/DefaultRatingView.cs
+++ b/src/Platforms/Ios/DefaultRatingView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Foundation;
 using StoreKit;
 using UIKit;
@@ -23,6 +24,32 @@ namespace Griesoft.Xamarin.RatingGateway
                 SKStoreReviewController.RequestReview();
             }
             else if (runBeforeOpen != null && !runBeforeOpen())
+            {
+                // Don't do anything if the runBeforeOpen function returned false
+            }
+            else if (systemVersion >= new Version(8, 0))
+            {
+                UIApplication.SharedApplication.OpenUrl(new NSUrl(AppStoreReviewUrlIOS8.Replace("YOUR_APP_ID", NSBundle.MainBundle.BundleIdentifier)));
+            }
+            else if (systemVersion >= new Version(7, 0))
+            {
+                UIApplication.SharedApplication.OpenUrl(new NSUrl($"{AppStoreReviewUrlIOS7}{NSBundle.MainBundle.BundleIdentifier}"));
+            }
+            else
+            {
+                UIApplication.SharedApplication.OpenUrl(new NSUrl($"{AppStoreReviewUrl}{NSBundle.MainBundle.BundleIdentifier}"));
+            }
+        }
+
+        internal static async Task PlatformTryOpenRatingPageAsync(Func<Task<bool>>? runBeforeOpenAsync = default)
+        {
+            var systemVersion = ParseVersion(UIDevice.CurrentDevice.SystemVersion);
+
+            if (systemVersion >= new Version(10, 3))
+            {
+                SKStoreReviewController.RequestReview();
+            }
+            else if (runBeforeOpenAsync != null && !await runBeforeOpenAsync())
             {
                 // Don't do anything if the runBeforeOpen function returned false
             }

--- a/src/Platforms/Ios/DefaultRatingView.cs
+++ b/src/Platforms/Ios/DefaultRatingView.cs
@@ -14,13 +14,17 @@ namespace Griesoft.Xamarin.RatingGateway
         private const string AppStoreReviewUrlIOS7 = "itms-apps://itunes.apple.com/app/id";
         private const string AppStoreReviewUrlIOS8 = "itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=YOUR_APP_ID&amp;onlyLatestVersion=true&amp;pageNumber=0&amp;sortOrdering=1&amp;type=Purple+Software";
 
-        internal static void PlatformTryOpenRatingPage()
+        internal static void PlatformTryOpenRatingPage(Func<bool>? runBeforeOpen = default)
         {
             var systemVersion = ParseVersion(UIDevice.CurrentDevice.SystemVersion);
 
             if (systemVersion >= new Version(10, 3))
             {
                 SKStoreReviewController.RequestReview();
+            }
+            else if (runBeforeOpen != null && !runBeforeOpen())
+            {
+                // Don't do anything if the runBeforeOpen function returned false
             }
             else if (systemVersion >= new Version(8, 0))
             {

--- a/src/Platforms/Standard/DefaultRatingView.cs
+++ b/src/Platforms/Standard/DefaultRatingView.cs
@@ -10,7 +10,8 @@ namespace Griesoft.Xamarin.RatingGateway
     /// </remarks>
     public sealed partial class DefaultRatingView
     {
-        internal static void PlatformTryOpenRatingPage() =>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "We need to match the signature in each platform project, even that the parameter would never be used.")]
+        internal static void PlatformTryOpenRatingPage(Func<bool>? runBeforeOpen = default) =>
             throw new NotImplementedException("Install this package on each platform project that you intent to use this package with.");
     }
 }

--- a/src/Platforms/Standard/DefaultRatingView.cs
+++ b/src/Platforms/Standard/DefaultRatingView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Griesoft.Xamarin.RatingGateway
 {
@@ -12,6 +13,11 @@ namespace Griesoft.Xamarin.RatingGateway
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "We need to match the signature in each platform project, even that the parameter would never be used.")]
         internal static void PlatformTryOpenRatingPage(Func<bool>? runBeforeOpen = default) =>
+            throw new NotImplementedException("Install this package on each platform project that you intent to use this package with.");
+
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "We need to match the signature in each platform project, even that the parameter would never be used.")]
+        internal static Task PlatformTryOpenRatingPageAsync(Func<Task<bool>>? runBeforeOpenAsync = default) =>
             throw new NotImplementedException("Install this package on each platform project that you intent to use this package with.");
     }
 }

--- a/src/RatingGateway.cs
+++ b/src/RatingGateway.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Griesoft.Xamarin.RatingGateway.Cache;
 using Griesoft.Xamarin.RatingGateway.Conditions;
 
@@ -246,6 +247,86 @@ namespace Griesoft.Xamarin.RatingGateway
             if (evaluationResult)
             {
                 RatingView.TryOpenRatingPage();
+            }
+
+            ResetAllMetConditions(evaluationResult);
+        }
+
+        /// <summary>
+        /// Evaluate through all conditions in the collection and if all necessary conditions are met open the rating page asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// Use <see cref="Evaluate"/> if you are not sure about which one to use.
+        /// <para/>
+        /// The evaluation process will first manipulate all conditions that allow implicit manipulation by using their parameterless manipulation method.
+        /// After manipulation, the actual evaluation will happen, and after evaluation has finished all met conditions will be reset which allow automatic reset.
+        /// </remarks>
+        public async Task EvaluateAsync()
+        {
+            ManipulateConditionState(null);
+
+            var evaluationResult = EvaluateConditions();
+
+            if (evaluationResult)
+            {
+                await RatingView.TryOpenRatingPageAsync();
+            }
+
+            ResetAllMetConditions(evaluationResult);
+        }
+
+        /// <summary>
+        /// Evaluate through all conditions in the collection and if all necessary conditions are met open the rating page asynchronously.
+        /// </summary>
+        /// <param name="conditionName">The unique name of the condition that should be prioritized.</param>
+        /// <param name="parameter">An optional parameter that will be passed to the manipulation process for the specified condition.</param>
+        /// <param name="manipulateOnly">Set to true if the specified condition should not be prioritized in the actual evaluation phase and be used for manipulation only. The default is false.</param>
+        /// <remarks>
+        /// Use <see cref="Evaluate(string, object?, bool)"/> if you are not sure about which one to use.
+        /// <para/>
+        /// The evaluation process will first manipulate all conditions that allow implicit manipulation by using their parameterless manipulation method.
+        /// After manipulation, the actual evaluation will happen, and after evaluation has finished all met conditions will be reset which allow automatic reset.
+        /// <para/>
+        /// If the specified condition is not used for manipulation only, it will be prioritized by the evaluator. This means that the prioritized condition must be
+        /// met in addition to all prerequisite and required conditions, before evaluating to true.
+        /// </remarks>
+        public async Task EvaluateAsync(string conditionName, object? parameter = default, bool manipulateOnly = false)
+        {
+            ManipulateConditionState(new Dictionary<string, object?>() { { conditionName, parameter } });
+
+            var evaluationResult = EvaluateConditions(manipulateOnly ? null : new List<string>() { conditionName });
+
+            if (evaluationResult)
+            {
+                await RatingView.TryOpenRatingPageAsync();
+            }
+
+            ResetAllMetConditions(evaluationResult);
+        }
+
+        /// <summary>
+        /// Evaluate through all conditions in the collection and if all necessary conditions are met open the rating page asynchronously.
+        /// </summary>
+        /// <param name="parameters">A collection of unique condition names and optional parameters for them.</param>
+        /// <param name="manipulateOnly">Set to true if the specified conditions should not be prioritized in the actual evaluation phase and be used for manipulation only. The default is false.</param>
+        /// <remarks>
+        /// Use <see cref="Evaluate(Dictionary{string, object?}, bool)"/> if you are not sure about which one to use.
+        /// <para/>
+        /// The evaluation process will first manipulate all conditions that allow implicit manipulation by using their parameterless manipulation method.
+        /// After manipulation, the actual evaluation will happen, and after evaluation has finished all met conditions will be reset which allow automatic reset.
+        /// <para/>
+        /// If the specified conditions are not used for manipulation only, they will be prioritized by the evaluator. This means that the prioritized conditions must be
+        /// met in addition to all prerequisite and required conditions, before evaluating to true.
+        /// </remarks>
+        public async Task EvaluateAsync(Dictionary<string, object?> parameters, bool manipulateOnly = false)
+        {
+            ManipulateConditionState(parameters);
+
+            var evaluationResult = EvaluateConditions(manipulateOnly ? null : parameters?.Keys);
+
+            if (evaluationResult)
+            {
+                await RatingView.TryOpenRatingPageAsync();
             }
 
             ResetAllMetConditions(evaluationResult);

--- a/src/RatingGateway.csproj
+++ b/src/RatingGateway.csproj
@@ -6,10 +6,10 @@
     <PackageId>Griesoft.Xamarin.RatingGateway</PackageId>
     <Company>Griesinger Software</Company>
     <Authors>Joonas Griesinger</Authors>
-    <Owners>jgdevlabs,jooni91</Owners>
+    <Owners>jgdevlabs;jooni91</Owners>
     <Title>Xamarin Rating Gateway</Title>
-    <Description>A rating gateway which takes care of when to prompt the user to review your Xamarin application by evaluating through a set of defined conditions each time a rating action is triggered by the user.</Description>
-    <PackageTags>ios;android;xamarin;rating;review;xamarin rating gateway; xamarin rating; xamarin review</PackageTags>
+    <Description>A rating gateway which takes care of when to prompt the user to review your Xamarin application, by evaluating through a set of defined conditions each time a rating action is triggered by the user.</Description>
+    <PackageTags>ios;android;xamarin;rating;review;xamarin rating gateway; xamarin rating; xamarin review; rating system; review tool</PackageTags>
     <PackageVersion>1.0.0</PackageVersion>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageIconUrl></PackageIconUrl>

--- a/tests/RatingGatewayTests.cs
+++ b/tests/RatingGatewayTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Griesoft.Xamarin.RatingGateway.Cache;
 using Griesoft.Xamarin.RatingGateway.Conditions;
 using Moq;
@@ -682,6 +683,512 @@ namespace Griesoft.Xamarin.RatingGateway.Tests
             Assert.Equal(1, condition1.CurrentState);
             Assert.Equal(0, condition2.CurrentState);
             Assert.Equal(1, condition3.CurrentState);
+        }
+
+        [Fact]
+        public void Evaluate_OpensRatingPage()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            var condition1 = new CountRatingCondition(0, 1) { CacheCurrentValue = false };
+            gateway.AddCondition("test", condition1);
+
+            // Act
+            gateway.Evaluate();
+            gateway.Evaluate("test");
+            gateway.Evaluate(new Dictionary<string, object?>() { { "test", null } });
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Exactly(3));
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Never);
+        }
+
+        [Theory]
+        [InlineData("Test", 8, false, false, 8)]
+        [InlineData("Test", 5, true, false, 5)]
+        [InlineData("Test", null, false, false, 1)]
+        [InlineData("Test", null, false, true, 0)]
+        [InlineData("Test", null, true, false, 1)]
+        [InlineData(null, null, false, false, 1)]
+        [InlineData(null, 5, true, false, 0)]
+        [InlineData(null, 8, false, false, 1)]
+        public async Task EvaluateAsync_DoesManipulate_AsExpected(string? key, int? param, bool explicitOnly, bool disallowParameterless, int expected)
+        {
+            // Arrange
+            var condition = new CountRatingCondition(0, 10)
+            {
+                ExplicitManipulationOnly = explicitOnly,
+                DisallowParamaterlessManipulation = disallowParameterless,
+                CacheCurrentValue = false
+            };
+            var gateway = new RatingGateway();
+            gateway.AddCondition(key ?? nameof(CountRatingCondition), condition);
+
+            // Act
+            if (key == null)
+            {
+                await gateway.EvaluateAsync();
+            }
+            else
+            {
+                await gateway.EvaluateAsync(new Dictionary<string, object?>()
+                {
+                    { key, param }
+                });
+            }
+
+            // Assert
+            Assert.Equal(expected, condition.CurrentState);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_ManipulateShould_SaveStateOfCachables()
+        {
+            // Arrange
+            var cacheStub = new Mock<IRatingConditionCache>();
+            cacheStub.Setup(cache => cache.Load(It.IsAny<string>(), It.IsAny<ICachableCondition>())).Returns(true);
+            var ratingGateway = new RatingGateway()
+            {
+                RatingConditionCache = cacheStub.Object
+            };
+            ratingGateway.AddCondition("test", new BooleanRatingCondition());
+            ratingGateway.AddCondition("test2", new CountRatingCondition(0, 3));
+
+            // Act
+            await ratingGateway.EvaluateAsync(new Dictionary<string, object?>()
+            {
+                { "test", null },
+                { "test2", null }
+            });
+            await ratingGateway.EvaluateAsync(new Dictionary<string, object?>()
+            {
+                { "test", false },
+                { "test2", 1 }
+            });
+
+            // Assert
+            cacheStub.Verify(cache => cache.Save(It.IsAny<string>(), It.IsAny<ICachableCondition>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_FailsWhen_HasOnlyPrerequisites()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            gateway.AddCondition("test", new BooleanRatingCondition(ConditionType.Prerequisite));
+
+            // Act
+            await gateway.EvaluateAsync();
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_FailsWhen_PrerequisitesNotMet()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            gateway.AddCondition("test", new CountRatingCondition(0, 5, ConditionType.Prerequisite) { CacheCurrentValue = false });
+            gateway.AddCondition("test2", new BooleanRatingCondition());
+
+            // Act
+            await gateway.EvaluateAsync();
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_SucceedsWhen_PrerequisitesAndStandardConditionsMet()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            gateway.AddCondition("test", new BooleanRatingCondition(ConditionType.Prerequisite));
+            gateway.AddCondition("test2", new BooleanRatingCondition());
+
+            // Act
+            await gateway.EvaluateAsync();
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_FailsWhen_PrerequisitesMetButStandardConditionNot()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            gateway.AddCondition("test", new BooleanRatingCondition(ConditionType.Prerequisite));
+            gateway.AddCondition("test2", new CountRatingCondition(0, 5) { CacheCurrentValue = false });
+
+            // Act
+            await gateway.EvaluateAsync();
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_FailsWhen_RequiredConditionsNotMet()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            gateway.AddCondition("test", new BooleanRatingCondition());
+            gateway.AddCondition("test2", new CountRatingCondition(0, 5, ConditionType.Requirement) { CacheCurrentValue = false });
+
+            // Act
+            await gateway.EvaluateAsync();
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_FailsWhen_NotAllRequiredMed()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            gateway.AddCondition("test", new BooleanRatingCondition(ConditionType.Requirement));
+            gateway.AddCondition("test2", new CountRatingCondition(0, 5, ConditionType.Requirement) { CacheCurrentValue = false });
+
+            // Act
+            await gateway.EvaluateAsync();
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_SucceedsWhen_RequiredMetAndNoPrioritySpecified()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            gateway.AddCondition("test", new BooleanRatingCondition(ConditionType.Requirement));
+            gateway.AddCondition("test2", new CountRatingCondition(0, 5) { CacheCurrentValue = false });
+
+            // Act
+            await gateway.EvaluateAsync();
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_FailsWhen_RequiredMetAndPrioritySpecified()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            gateway.AddCondition("test", new BooleanRatingCondition(ConditionType.Requirement));
+            gateway.AddCondition("test2", new CountRatingCondition(0, 5) { CacheCurrentValue = false });
+
+            // Act
+            await gateway.EvaluateAsync("test2");
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_FailsWhen_PriorityNotMet()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            gateway.AddCondition("test", new BooleanRatingCondition());
+            gateway.AddCondition("test2", new CountRatingCondition(0, 5) { CacheCurrentValue = false });
+
+            // Act
+            await gateway.EvaluateAsync("test2");
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_FailsWhen_NotAllPrioritysAreMet()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            gateway.AddCondition("test", new BooleanRatingCondition());
+            gateway.AddCondition("test2", new CountRatingCondition(0, 5) { CacheCurrentValue = false });
+            gateway.AddCondition("test3", new BooleanRatingCondition());
+
+            // Act
+            await gateway.EvaluateAsync(new Dictionary<string, object?>()
+            {
+                { "test", null },
+                { "test2", null }
+            });
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_FailsWhen_PriorityDoesNotExist()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            gateway.AddCondition("test", new BooleanRatingCondition());
+            gateway.AddCondition("test2", new CountRatingCondition(0, 5) { CacheCurrentValue = false });
+            gateway.AddCondition("test3", new BooleanRatingCondition());
+
+            // Act
+            await gateway.EvaluateAsync("random");
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_FailsWhen_NoConditionMet()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            gateway.AddCondition("test", new CountRatingCondition(0, 5) { CacheCurrentValue = false });
+            gateway.AddCondition("test2", new CountRatingCondition(0, 10) { CacheCurrentValue = false });
+
+            // Act
+            await gateway.EvaluateAsync();
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_SucceedsWhen_AnyConditionIsMet()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            gateway.AddCondition("test", new CountRatingCondition(0, 5) { CacheCurrentValue = false });
+            gateway.AddCondition("test2", new BooleanRatingCondition());
+
+            // Act
+            await gateway.EvaluateAsync();
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_ManipulationOnlyDoes_EvaluateWithoutPriorityCondition()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            gateway.AddCondition("test", new CountRatingCondition(0, 5) { CacheCurrentValue = false });
+            gateway.AddCondition("test2", new BooleanRatingCondition());
+
+            // Act
+            await gateway.EvaluateAsync("test", 3, true);
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_DoesResetAllMetConditions()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            var condition1 = new CountRatingCondition(0, 1, ConditionType.Requirement) { CacheCurrentValue = false };
+            var condition2 = new BooleanRatingCondition(ConditionType.Requirement);
+            gateway.AddCondition("test", condition1);
+            gateway.AddCondition("test2", condition2);
+
+            // Act
+            await gateway.EvaluateAsync();
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Once);
+            Assert.Equal(0, condition1.CurrentState);
+            Assert.False(condition2.CurrentState);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_ResetAllMetConditionsShould_SaveStateOfCachables()
+        {
+            // Arrange
+            var ratingViewStub = new Mock<IRatingView>();
+            var cacheStub = new Mock<IRatingConditionCache>();
+            cacheStub.Setup(cache => cache.Load(It.IsAny<string>(), It.IsAny<ICachableCondition>())).Returns(true);
+            var ratingGateway = new RatingGateway()
+            {
+                RatingView = ratingViewStub.Object,
+                RatingConditionCache = cacheStub.Object
+            };
+            ratingGateway.AddCondition("test", new CountRatingCondition(0, 1) { CacheCurrentValue = false });
+            ratingGateway.AddCondition("test2", new CountRatingCondition(0, 1));
+
+            // Act
+            await ratingGateway.EvaluateAsync(new Dictionary<string, object?>()
+            {
+                { "test", null },
+                { "test2", null }
+            });
+
+            // Assert
+            ratingViewStub.Verify(rating => rating.TryOpenRatingPage(), Times.Never);
+            ratingViewStub.Verify(view => view.TryOpenRatingPageAsync(), Times.Once);
+            cacheStub.Verify(cache => cache.Save(It.IsAny<string>(), It.IsAny<ICachableCondition>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_DoesResetAllMetConditions_ExceptStrictlyForbiddenOnes()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            var condition1 = new CountRatingCondition(0, 1, ConditionType.Requirement) { CacheCurrentValue = false };
+            var condition2 = new BooleanRatingCondition(ConditionType.Requirement)
+            {
+                ResetAfterConditionMet = false
+            };
+            gateway.AddCondition("test", condition1);
+            gateway.AddCondition("test2", condition2);
+
+            // Act
+            await gateway.EvaluateAsync();
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Once);
+            Assert.Equal(0, condition1.CurrentState);
+            Assert.True(condition2.CurrentState);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_ResetOnlyWhen_EvaluationSuccess()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            var condition1 = new CountRatingCondition(0, 2, ConditionType.Requirement) { CacheCurrentValue = false };
+            var condition2 = new CountRatingCondition(0, 1, ConditionType.Requirement)
+            {
+                CacheCurrentValue = false,
+                ResetOnlyOnEvaluationSuccess = false
+            };
+            var condition3 = new CountRatingCondition(0, 1, ConditionType.Requirement) { CacheCurrentValue = false };
+            gateway.AddCondition("test", condition1);
+            gateway.AddCondition("test2", condition2);
+            gateway.AddCondition("test3", condition3);
+
+            // Act
+            await gateway.EvaluateAsync();
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Never);
+            Assert.Equal(1, condition1.CurrentState);
+            Assert.Equal(0, condition2.CurrentState);
+            Assert.Equal(1, condition3.CurrentState);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_OpensRatingPageAsync()
+        {
+            // Arrange
+            var ratingViewMock = new Mock<IRatingView>();
+            var gateway = new RatingGateway
+            {
+                RatingView = ratingViewMock.Object
+            };
+            var condition1 = new CountRatingCondition(0, 1) { CacheCurrentValue = false };
+            gateway.AddCondition("test", condition1);
+
+            // Act
+            await gateway.EvaluateAsync();
+            await gateway.EvaluateAsync("test");
+            await gateway.EvaluateAsync(new Dictionary<string, object?>() { { "test", null } });
+
+            // Assert
+            ratingViewMock.Verify(view => view.TryOpenRatingPage(), Times.Never);
+            ratingViewMock.Verify(view => view.TryOpenRatingPageAsync(), Times.Exactly(3));
         }
     }
 }


### PR DESCRIPTION
## Last chance Func
Added two constructors, in addition to the default one, to the `DefaultRatingView`. You can pass a "last chance" **Func** as a parameter when creating a new instance. This Func will be called just before navigating to the store page of the app and can be used to intercept that from happening if necessary. So you can make your own additional checks or first ask the user if they want to review your app, for example. Not doing that can have a negative impact on your user experience.

**Note,** that it will only be called if showing an *In-App Review* is not possible. 

So at the moment in the case of Android, we would do that every time and on iOS only if the OS version is smaller then 10.3.

## Async TryOpenRatingPage
Added also a `TryOpenRatingPageAsync `method to the `IRatingView` and a default implementation in the `DefaultRatingView`.

Also, the `RatingGateway` has now separate `EvaluateAsync(...)` versions of the Evaluate method. They make use of the TryOpenRatingPageAsync.

Make sure to call the appropriate method for your use case. If you don't use an async last chance function you probably should always use just `Evaluate(...)`.

## Meta changes
Made small fixes to the metadata of the NuGet package.