### PR TITLE
Change to Initilize and RatingGateway.Current

### DIFF
--- a/docs/Griesoft.Xamarin.RatingGateway.xml
+++ b/docs/Griesoft.Xamarin.RatingGateway.xml
@@ -566,7 +566,7 @@
             <param name="condition">The condition instance that will be added to the collection.</param>
             <param name="ratingView">Optional; pass a custom rating view. If not specified or null, <see cref="T:Griesoft.Xamarin.RatingGateway.DefaultRatingView"/> will be used instead.</param>
             <param name="ratingCache">Optional; pass a custom condition cache. If not specified or null, <see cref="T:Griesoft.Xamarin.RatingGateway.Cache.DefaultRatingConditionCache"/> will be used instead.</param>
-            <remarks>Can be only called once in the lifetime of a <see cref="T:Griesoft.Xamarin.RatingGateway.RatingGateway"/>. All other calls after the initial one, do just return.</remarks>
+            <remarks>Call it only once in the lifetime of a <see cref="T:Griesoft.Xamarin.RatingGateway.RatingGateway"/>. All other calls after the initial one, do just return.</remarks>
         </member>
         <member name="M:Griesoft.Xamarin.RatingGateway.RatingGateway.Initialize(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,Griesoft.Xamarin.RatingGateway.Conditions.IRatingCondition}},Griesoft.Xamarin.RatingGateway.IRatingView,Griesoft.Xamarin.RatingGateway.Cache.IRatingConditionCache)">
             <summary>
@@ -575,7 +575,7 @@
             <param name="conditions">A collection of key value pairs where the key will be used as the unique condition name and the value is added to the condition collection.</param>
             <param name="ratingView">Optional; pass a custom rating view. If not specified or null, <see cref="T:Griesoft.Xamarin.RatingGateway.DefaultRatingView"/> will be used instead.</param>
             <param name="ratingCache">Optional; pass a custom condition cache. If not specified or null, <see cref="T:Griesoft.Xamarin.RatingGateway.Cache.DefaultRatingConditionCache"/> will be used instead.</param>
-            <remarks>Can be only called once in the lifetime of a <see cref="T:Griesoft.Xamarin.RatingGateway.RatingGateway"/>. All other calls after the initial one, do just return.</remarks>
+            <remarks>Call it only once in the lifetime of a <see cref="T:Griesoft.Xamarin.RatingGateway.RatingGateway"/>. All other calls after the initial one, do just return.</remarks>
         </member>
         <member name="M:Griesoft.Xamarin.RatingGateway.RatingGateway.AddCondition(System.String,Griesoft.Xamarin.RatingGateway.Conditions.IRatingCondition)">
             <summary>

--- a/docs/Griesoft.Xamarin.RatingGateway.xml
+++ b/docs/Griesoft.Xamarin.RatingGateway.xml
@@ -555,7 +555,7 @@
         </member>
         <member name="P:Griesoft.Xamarin.RatingGateway.RatingGateway.Current">
             <summary>
-            The singleton instance of this rating gateway. Returns null if the service was not initialized on application startup.
+            A singleton instance of the rating gateway.
             </summary>
         </member>
         <member name="M:Griesoft.Xamarin.RatingGateway.RatingGateway.Initialize(System.String,Griesoft.Xamarin.RatingGateway.Conditions.IRatingCondition,Griesoft.Xamarin.RatingGateway.IRatingView,Griesoft.Xamarin.RatingGateway.Cache.IRatingConditionCache)">
@@ -566,7 +566,7 @@
             <param name="condition">The condition instance that will be added to the collection.</param>
             <param name="ratingView">Optional; pass a custom rating view. If not specified or null, <see cref="T:Griesoft.Xamarin.RatingGateway.DefaultRatingView"/> will be used instead.</param>
             <param name="ratingCache">Optional; pass a custom condition cache. If not specified or null, <see cref="T:Griesoft.Xamarin.RatingGateway.Cache.DefaultRatingConditionCache"/> will be used instead.</param>
-            <exception cref="T:System.ArgumentException">Thrown if a condition with the given name already exists in the collection.</exception>
+            <remarks>Can be only called once in the lifetime of a <see cref="T:Griesoft.Xamarin.RatingGateway.RatingGateway"/>. All other calls after the initial one, do just return.</remarks>
         </member>
         <member name="M:Griesoft.Xamarin.RatingGateway.RatingGateway.Initialize(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,Griesoft.Xamarin.RatingGateway.Conditions.IRatingCondition}},Griesoft.Xamarin.RatingGateway.IRatingView,Griesoft.Xamarin.RatingGateway.Cache.IRatingConditionCache)">
             <summary>
@@ -575,7 +575,7 @@
             <param name="conditions">A collection of key value pairs where the key will be used as the unique condition name and the value is added to the condition collection.</param>
             <param name="ratingView">Optional; pass a custom rating view. If not specified or null, <see cref="T:Griesoft.Xamarin.RatingGateway.DefaultRatingView"/> will be used instead.</param>
             <param name="ratingCache">Optional; pass a custom condition cache. If not specified or null, <see cref="T:Griesoft.Xamarin.RatingGateway.Cache.DefaultRatingConditionCache"/> will be used instead.</param>
-            <exception cref="T:System.ArgumentException">Thrown if a condition with the given name already exists in the collection.</exception>
+            <remarks>Can be only called once in the lifetime of a <see cref="T:Griesoft.Xamarin.RatingGateway.RatingGateway"/>. All other calls after the initial one, do just return.</remarks>
         </member>
         <member name="M:Griesoft.Xamarin.RatingGateway.RatingGateway.AddCondition(System.String,Griesoft.Xamarin.RatingGateway.Conditions.IRatingCondition)">
             <summary>

--- a/src/RatingGateway.cs
+++ b/src/RatingGateway.cs
@@ -69,7 +69,7 @@ namespace Griesoft.Xamarin.RatingGateway
         /// <summary>
         /// A singleton instance of the rating gateway.
         /// </summary>
-        public static RatingGateway? Current { get; private set; }
+        public static RatingGateway Current { get; } = new RatingGateway();
 
         /// <summary>
         /// Initialize the rating gateway with a single condition.
@@ -78,28 +78,26 @@ namespace Griesoft.Xamarin.RatingGateway
         /// <param name="condition">The condition instance that will be added to the collection.</param>
         /// <param name="ratingView">Optional; pass a custom rating view. If not specified or null, <see cref="DefaultRatingView"/> will be used instead.</param>
         /// <param name="ratingCache">Optional; pass a custom condition cache. If not specified or null, <see cref="DefaultRatingConditionCache"/> will be used instead.</param>
-        /// <remarks>Can be only called once in the lifetime of a <see cref="RatingGateway"/>. All other calls after the initial one, do just return.</remarks>
+        /// <remarks>Call it only once in the lifetime of a <see cref="RatingGateway"/>. All other calls after the initial one, do just return.</remarks>
         public static void Initialize(string conditionName, IRatingCondition condition, IRatingView? ratingView = default, IRatingConditionCache? ratingCache = default)
         {
-            var ratingGateway = CreateNewGatewayInstance();
-
-            if (ratingGateway.IsInitialized)
+            if (Current.IsInitialized)
             {
                 return;
             }
 
-            ratingGateway.IsInitialized = true;
+            Current.IsInitialized = true;
 
-            ratingGateway.AddCondition(conditionName, condition);
+            Current.AddCondition(conditionName, condition);
 
             if (ratingView != null)
             {
-                ratingGateway.RatingView = ratingView;
+                Current.RatingView = ratingView;
             }
 
             if (ratingCache != null)
             {
-                ratingGateway.RatingConditionCache = ratingCache;
+                Current.RatingConditionCache = ratingCache;
             }
         }
 
@@ -109,28 +107,26 @@ namespace Griesoft.Xamarin.RatingGateway
         /// <param name="conditions">A collection of key value pairs where the key will be used as the unique condition name and the value is added to the condition collection.</param>
         /// <param name="ratingView">Optional; pass a custom rating view. If not specified or null, <see cref="DefaultRatingView"/> will be used instead.</param>
         /// <param name="ratingCache">Optional; pass a custom condition cache. If not specified or null, <see cref="DefaultRatingConditionCache"/> will be used instead.</param>
-        /// <remarks>Can be only called once in the lifetime of a <see cref="RatingGateway"/>. All other calls after the initial one, do just return.</remarks>
+        /// <remarks>Call it only once in the lifetime of a <see cref="RatingGateway"/>. All other calls after the initial one, do just return.</remarks>
         public static void Initialize(IEnumerable<KeyValuePair<string, IRatingCondition>> conditions, IRatingView? ratingView = default, IRatingConditionCache? ratingCache = default)
         {
-            var ratingGateway = CreateNewGatewayInstance();
-
-            if (ratingGateway.IsInitialized)
+            if (Current.IsInitialized)
             {
                 return;
             }
 
-            ratingGateway.IsInitialized = true;
+            Current.IsInitialized = true;
 
-            ratingGateway.AddCondition(conditions);
+            Current.AddCondition(conditions);
 
             if (ratingView != null)
             {
-                ratingGateway.RatingView = ratingView;
+                Current.RatingView = ratingView;
             }
 
             if (ratingCache != null)
             {
-                ratingGateway.RatingConditionCache = ratingCache;
+                Current.RatingConditionCache = ratingCache;
             }
         }
 
@@ -346,16 +342,6 @@ namespace Griesoft.Xamarin.RatingGateway
             }
 
             ResetAllMetConditions(evaluationResult);
-        }
-
-        private static RatingGateway CreateNewGatewayInstance()
-        {
-            if (Current == null)
-            {
-                Current = new RatingGateway();
-            }
-
-            return Current;
         }
 
         private void ResetAllMetConditions(bool evaluationResult)

--- a/src/RatingGateway.cs
+++ b/src/RatingGateway.cs
@@ -31,6 +31,8 @@ namespace Griesoft.Xamarin.RatingGateway
             RatingConditionCache = new DefaultRatingConditionCache();
         }
 
+        private bool IsInitialized { get; set; } = false;
+
         /// <summary>
         /// The condition collection returned as an enumerable.
         /// </summary>
@@ -65,7 +67,7 @@ namespace Griesoft.Xamarin.RatingGateway
         public IRatingConditionCache RatingConditionCache { get; set; }
 
         /// <summary>
-        /// The singleton instance of this rating gateway. Returns null if the service was not initialized on application startup.
+        /// A singleton instance of the rating gateway.
         /// </summary>
         public static RatingGateway? Current { get; private set; }
 
@@ -76,10 +78,17 @@ namespace Griesoft.Xamarin.RatingGateway
         /// <param name="condition">The condition instance that will be added to the collection.</param>
         /// <param name="ratingView">Optional; pass a custom rating view. If not specified or null, <see cref="DefaultRatingView"/> will be used instead.</param>
         /// <param name="ratingCache">Optional; pass a custom condition cache. If not specified or null, <see cref="DefaultRatingConditionCache"/> will be used instead.</param>
-        /// <exception cref="System.ArgumentException">Thrown if a condition with the given name already exists in the collection.</exception>
+        /// <remarks>Can be only called once in the lifetime of a <see cref="RatingGateway"/>. All other calls after the initial one, do just return.</remarks>
         public static void Initialize(string conditionName, IRatingCondition condition, IRatingView? ratingView = default, IRatingConditionCache? ratingCache = default)
         {
             var ratingGateway = CreateNewGatewayInstance();
+
+            if (ratingGateway.IsInitialized)
+            {
+                return;
+            }
+
+            ratingGateway.IsInitialized = true;
 
             ratingGateway.AddCondition(conditionName, condition);
 
@@ -100,10 +109,17 @@ namespace Griesoft.Xamarin.RatingGateway
         /// <param name="conditions">A collection of key value pairs where the key will be used as the unique condition name and the value is added to the condition collection.</param>
         /// <param name="ratingView">Optional; pass a custom rating view. If not specified or null, <see cref="DefaultRatingView"/> will be used instead.</param>
         /// <param name="ratingCache">Optional; pass a custom condition cache. If not specified or null, <see cref="DefaultRatingConditionCache"/> will be used instead.</param>
-        /// <exception cref="System.ArgumentException">Thrown if a condition with the given name already exists in the collection.</exception>
+        /// <remarks>Can be only called once in the lifetime of a <see cref="RatingGateway"/>. All other calls after the initial one, do just return.</remarks>
         public static void Initialize(IEnumerable<KeyValuePair<string, IRatingCondition>> conditions, IRatingView? ratingView = default, IRatingConditionCache? ratingCache = default)
         {
             var ratingGateway = CreateNewGatewayInstance();
+
+            if (ratingGateway.IsInitialized)
+            {
+                return;
+            }
+
+            ratingGateway.IsInitialized = true;
 
             ratingGateway.AddCondition(conditions);
 

--- a/tests/RatingGatewayTests.cs
+++ b/tests/RatingGatewayTests.cs
@@ -21,8 +21,9 @@ namespace Griesoft.Xamarin.RatingGateway.Tests
             RatingGateway.Initialize("Test", new BooleanRatingCondition());
 
             // Assert
-            Assert.NotNull(RatingGateway.Current?.RatingView);
-            Assert.NotNull(RatingGateway.Current?.RatingConditionCache);
+            Assert.NotNull(RatingGateway.Current.RatingView);
+            Assert.NotNull(RatingGateway.Current.RatingConditionCache);
+            Assert.Single(RatingGateway.Current.RatingConditions);
         }
 
         [Fact]
@@ -36,8 +37,9 @@ namespace Griesoft.Xamarin.RatingGateway.Tests
 
 
             // Assert
-            Assert.NotNull(RatingGateway.Current?.RatingView);
-            Assert.NotNull(RatingGateway.Current?.RatingConditionCache);
+            Assert.NotNull(RatingGateway.Current.RatingView);
+            Assert.NotNull(RatingGateway.Current.RatingConditionCache);
+            Assert.Single(RatingGateway.Current.RatingConditions);
 
             // By calling initialize twice, if the second call would not return it would throw a ArgumentExecption,
             // because adding a condition with the same key is not possible.

--- a/tests/RatingGatewayTests.cs
+++ b/tests/RatingGatewayTests.cs
@@ -26,6 +26,25 @@ namespace Griesoft.Xamarin.RatingGateway.Tests
         }
 
         [Fact]
+        public void Initialize_Returns_OnSecondCall()
+        {
+            // Arrange
+            RatingGateway.Initialize("Test", new BooleanRatingCondition());
+
+            // Act
+            RatingGateway.Initialize("Test", new BooleanRatingCondition());
+
+
+            // Assert
+            Assert.NotNull(RatingGateway.Current?.RatingView);
+            Assert.NotNull(RatingGateway.Current?.RatingConditionCache);
+
+            // By calling initialize twice, if the second call would not return it would throw a ArgumentExecption,
+            // because adding a condition with the same key is not possible.
+
+        }
+
+        [Fact]
         public void HasPrerequisiteConditions_Returns_ExpectedResults()
         {
             // Arrange


### PR DESCRIPTION
## Initialize
Initialize should only be called once in the lifetime of the **RatingGateway**. So now when calling it the second time, it will only return and do nothing. 

This is to prevent cases were the RatingGateway lives longer then Activities on Android for example. When the user opens the app a new Activity will be created and the initialize logic would be triggered which would leed to an ArgumentException, because of adding conditions to the collection that already exist.

## RatingGateway.Current not null
The `RatingGateway.Current` property was changed to never return null.

This is just to make it more convenient, because there was no reason why we could not create a new instance of the RatingGateway and assign it to the **Current** property right away when the application is started.